### PR TITLE
modifications to send anchorsAdded/Updated/Removed events

### DIFF
--- a/WebARonARKit/WebARonARKit.js
+++ b/WebARonARKit/WebARonARKit.js
@@ -2838,6 +2838,26 @@
   VRDisplay = function() {
     var _layers = null;
 
+    var _listeners = {};
+ 
+    this.addEventListener = function(type, handler) {
+      if (!_listeners[type]) { _listeners[type] = []; }
+      _listeners[type].push(handler);
+    };
+
+    this.removeEventListener = function(type, handler) {
+      var handlers = _listeners[type];
+      if (!handlers) { return; }
+      var index = handlers.indexOf(handler);
+      if (index !== -1) handlers.splice(index, 1);
+    };
+
+    this.dispatchEvent = function(event) {
+      var handlers = _listeners[event.type];
+      if (!handlers) { return; }
+      handlers.forEach(function(handler) { handler(event); });
+    };
+
     /**
      * Whether the display is connected to the device.
      * @type {boolean}
@@ -3381,7 +3401,7 @@
     this.hasPassThroughCamera = false;
     return this;
   };
-
+ 
   /**
    * The enumeration of eyes for a VR/AR display device.
    * @type {{left: string, right: string}}
@@ -3589,7 +3609,7 @@
   * @constructor
   */
  window.WebARonARKitAnchorEvent = function(data) {
-   window.dispatchEvent(new CustomEvent('anchors' + data.type, { detail: data }));
+   WebARonARKitVRDisplay.dispatchEvent(new CustomEvent('anchors' + data.type, { detail: data }));
  };
  
   /**

--- a/WebARonARKit/WebARonARKit.js
+++ b/WebARonARKit/WebARonARKit.js
@@ -3581,6 +3581,17 @@
     callRafCallbacks();
   };
 
+ /**
+  * This function will be called from the native side upon an anchor event.
+  * @param {Object} data The data from native, which must contain the following properties:
+  *     type - a string describing the type of the anchor event.
+  *     anchors - an array of objects containing planes in the world.
+  * @constructor
+  */
+ window.WebARonARKitAnchorEvent = function(data) {
+   window.dispatchEvent(new CustomEvent('anchors' + data.type, { detail: data }));
+ };
+ 
   /**
    * If the window size has changed, the native side will call this function.
    * This is a hack due to WKWebView not handling the window.innerWidth/Height

--- a/WebARonARKit/WebARonARKit/ViewController.m
+++ b/WebARonARKit/WebARonARKit/ViewController.m
@@ -682,6 +682,79 @@
     }
 }
 
+- (void)session:(ARSession *)session notifyAnchorEvent:(NSString*)type anchors:(nonnull NSArray<ARAnchor *> *)anchors
+{
+    // The session did something to anchors; notify the JS side about it.
+    NSString *anchorsStr = @"[";
+    for (int i = 0; i < anchors.count; i++) {
+        ARPlaneAnchor *anchor = (ARPlaneAnchor *)anchors[i];
+        matrix_float4x4 anchorTransform = anchor.transform;
+        const float *anchorMatrix = (const float *)(&anchorTransform);
+        //NSLog(@"Plane extent (native) %@", [NSString stringWithFormat: @"%f,%f,%f", anchor.extent.x, anchor.extent.y, anchor.extent.z]);
+        NSString *anchorStr = [NSString stringWithFormat:
+                               @"{\"transform\":[%f,%f,%f,%f,%f,%f,%f,%"
+                               @"f,%f,%f,%f,%f,%f,%f,%f,%f],"
+                               @"\"identifier\":%i,"
+                               @"\"alignment\":%i,"
+                               @"\"center\":[%f,%f,%f],"
+                               @"\"extent\":[%f,%f]}",
+                               anchorMatrix[0], anchorMatrix[1], anchorMatrix[2],
+                               anchorMatrix[3], anchorMatrix[4], anchorMatrix[5],
+                               anchorMatrix[6], anchorMatrix[7], anchorMatrix[8],
+                               anchorMatrix[9], anchorMatrix[10], anchorMatrix[11],
+                               anchorMatrix[12], anchorMatrix[13], anchorMatrix[14],
+                               anchorMatrix[15],
+                               (int)anchor.identifier,
+                               (int)anchor.alignment,
+                               anchor.center.x, anchor.center.y, anchor.center.z,
+                               anchor.extent.x, anchor.extent.z];
+        if (i < anchors.count - 1) {
+            anchorStr = [anchorStr stringByAppendingString:@","];
+        }
+        anchorsStr = [anchorsStr stringByAppendingString:anchorStr];
+    }
+    anchorsStr = [anchorsStr stringByAppendingString:@"]"];
+    
+    NSString *jsCode = [NSString
+                        stringWithFormat:@"if (window.WebARonARKitAnchorEvent) "
+                        @"window.WebARonARKitAnchorEvent({"
+                        @"\"type\":\"%@\","
+                        @"\"anchors\":%@"
+                        @"});",
+                        type,
+                        anchorsStr];
+    
+    [self->wkWebView
+     evaluateJavaScript:jsCode
+     completionHandler:^(id data, NSError *error) {
+         if (error) {
+             [self showAlertDialog:
+              [NSString stringWithFormat:@"ERROR: Evaluating jscode: %@",
+               error]
+                 completionHandler:^{
+                 }];
+         }
+     }];
+}
+
+- (void)session:(ARSession *)session didAddAnchors:(nonnull NSArray<ARAnchor *> *)anchors
+{
+    // The session added anchors; notify the JS side about it.
+    [self session:session notifyAnchorEvent:@"Added" anchors:anchors];
+}
+
+- (void)session:(ARSession *)session didUpdateAnchors:(nonnull NSArray<ARAnchor *> *)anchors
+{
+    // The session updated anchors; notify the JS side about it.
+    [self session:session notifyAnchorEvent:@"Updated" anchors:anchors];
+}
+
+- (void)session:(ARSession *)session didRemoveAnchors:(nonnull NSArray<ARAnchor *> *)anchors
+{
+    // The session removed anchors; notify the JS side about it.
+    [self session:session notifyAnchorEvent:@"Removed" anchors:anchors];
+}
+
 #pragma mark - WKUIDelegate
 
 - (void)webView:(WKWebView *)webView


### PR DESCRIPTION
Simple changes to provide anchorsAdded / Updated / Removed events.

This performs much better than attempting to infer them solely from anchors array, mainly since ARKit does not provide any information about whether an anchor has changed within that array. 
Since Tango/ARCore have timestamps for anchors, inferring solely from anchors array in the ARCore implementation should be much more performant.