### PR TITLE
Improve the resize event handling with objects as callbacks

### DIFF
--- a/WebARonARKit/WebARonARKit.js
+++ b/WebARonARKit/WebARonARKit.js
@@ -3594,7 +3594,12 @@
     window.innerHeight = size.height;
     var resizeEvent = new Event("resize");
     for (var i = 0; i < resizeEventListeners.length; i++) {
-      resizeEventListeners[i].call(this, resizeEvent);
+      if (typeof(resizeEventListeners[i]) === "function") {
+        resizeEventListeners[i].call(this, resizeEvent);
+      }
+      else if (typeof(resizeEventListeners[i]) === "object" && typeof(resizeEventListeners[i].handleEvent) === "function") {
+        resizeEventListeners[i].handleEvent(resizeEvent);
+      }
     }
     if (typeof window.onresize === "function") {
       window.onresize.call(this, resizeEvent);


### PR DESCRIPTION
addEventListener can receive an object as a listener and then a handleEvent function is assumed. 
Made the changes to allow this possibility.

Change-Id: I39693f9076a599dbeec4b49866bd77fbd169e6f9