### PR TITLE
Update readme with debugging instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ A [list of example scenes](https://developers.google.com/ar/develop/web/getting-
 ### <a name="BuildingScenes">5. Building your own scenes</a>
 To build AR web experiences that work with WebARonARKit and [WebARonARCore for Android](https://github.com/google-ar/WebARonARCore), we recommend **[three.ar.js](https://github.com/google-ar/three.ar.js)**, a helper library that works with the popular [three.js](http://threejs.org) WebGL framework. [Three.ar.js](https://github.com/google-ar/three.ar.js) provides common AR building blocks, such as a visible reticle that draws on top of real world surfaces, and [example scenes](https://github.com/google-ar/three.ar.js#examples).
 
+### <a name="Debugging">6. Debugging </a>
+Pages in WebARonARKit can be inspected and debugged remotely with MacOS Safari, however this requires MacOS Safari 11.0 (available as Safari Technology Preview) or higher. You can download MacOS Safari 11 from https://developer.apple.com/safari/technology-preview/. 
 
 ## <a name="HowWebARonARKitWorks">How WebARonARKit works</a>
 

--- a/WebARonARKit/WebARonARKit.js
+++ b/WebARonARKit/WebARonARKit.js
@@ -3621,11 +3621,9 @@
     return window.getVRDisplaysPromise;
   };
 
-  // TODO: MacOS Safari and iOS 11 seem to have some kind of disagreement
-  // and it is to possible to debug the WKWebView (or a Safari iOS page).
-  // As console.log calls are not being shown in the XCode console, this
-  // reimplementation of console.log does the trick.
-  // This could be removed in case the Safari debugging tool is restored.
+  // TODO: iOS 11 Safari requires MacOS Safari 11 or higher to debug a WKWebVew (or any iOS Safari page). 
+  // Reimplementing console.log allows for logs to be shown in older versions of MacOS Safari.
+  // This could be removed once MacOS Safari 11.0 is released (currently available as Safari Technology Preview)
   var oldConsoleLog = console.log;
   console.log = function() {
     var argumentsArray = Array.prototype.slice.call(arguments);


### PR DESCRIPTION
Updates the readme and WebARonARKit.js with instructions for inspecting and debugging  WKWebView instances inside WebARonARKit