### PR TITLE
Sync fullscreen

### DIFF
--- a/WebARonARKit/WebARonARKit.js
+++ b/WebARonARKit/WebARonARKit.js
@@ -2838,6 +2838,26 @@
   VRDisplay = function() {
     var _layers = null;
 
+    var _listeners = {};
+ 
+    this.addEventListener = function(type, handler) {
+      if (!_listeners[type]) { _listeners[type] = []; }
+      _listeners[type].push(handler);
+    };
+
+    this.removeEventListener = function(type, handler) {
+      var handlers = _listeners[type];
+      if (!handlers) { return; }
+      var index = handlers.indexOf(handler);
+      if (index !== -1) handlers.splice(index, 1);
+    };
+
+    this.dispatchEvent = function(event) {
+      var handlers = _listeners[event.type];
+      if (!handlers) { return; }
+      handlers.forEach(function(handler) { handler(event); });
+    };
+
     /**
      * Whether the display is connected to the device.
      * @type {boolean}
@@ -3381,7 +3401,7 @@
     this.hasPassThroughCamera = false;
     return this;
   };
-
+ 
   /**
    * The enumeration of eyes for a VR/AR display device.
    * @type {{left: string, right: string}}
@@ -3589,7 +3609,7 @@
   * @constructor
   */
  window.WebARonARKitAnchorEvent = function(data) {
-   window.dispatchEvent(new CustomEvent('anchors' + data.type, { detail: data }));
+   WebARonARKitVRDisplay.dispatchEvent(new CustomEvent('anchors' + data.type, { detail: data }));
  };
  
   /**

--- a/WebARonARKit/WebARonARKit.js
+++ b/WebARonARKit/WebARonARKit.js
@@ -3581,6 +3581,17 @@
     callRafCallbacks();
   };
 
+ /**
+  * This function will be called from the native side upon an anchor event.
+  * @param {Object} data The data from native, which must contain the following properties:
+  *     type - a string describing the type of the anchor event.
+  *     anchors - an array of objects containing planes in the world.
+  * @constructor
+  */
+ window.WebARonARKitAnchorEvent = function(data) {
+   window.dispatchEvent(new CustomEvent('anchors' + data.type, { detail: data }));
+ };
+ 
   /**
    * If the window size has changed, the native side will call this function.
    * This is a hack due to WKWebView not handling the window.innerWidth/Height

--- a/WebARonARKit/WebARonARKit/ViewController.m
+++ b/WebARonARKit/WebARonARKit/ViewController.m
@@ -630,6 +630,9 @@
                          pProjectionMatrix[14], pProjectionMatrix[15],
                          anchors];
 
+    // Try blocking on return.
+    __block BOOL finished = NO;
+    
     [self->wkWebView
         evaluateJavaScript:jsCode
          completionHandler:^(id data, NSError *error) {
@@ -640,7 +643,14 @@
                      completionHandler:^{
                      }];
              }
+             finished = YES;
          }];
+    
+    // Try blocking up to 2 msec on return.
+    double endMediaTime = CACurrentMediaTime() + 0.002;
+    while (!finished && CACurrentMediaTime() < endMediaTime) {
+        [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode beforeDate:[NSDate distantFuture]];
+    }
 
     //This needs to be called after because the window size will affect the
     //projection matrix calculation upon resize

--- a/WebARonARKit/WebARonARKit/ViewController.m
+++ b/WebARonARKit/WebARonARKit/ViewController.m
@@ -682,6 +682,79 @@
     }
 }
 
+- (void)session:(ARSession *)session notifyAnchorEvent:(NSString*)type anchors:(nonnull NSArray<ARAnchor *> *)anchors
+{
+    // The session did something to anchors; notify the JS side about it.
+    NSString *anchorsStr = @"[";
+    for (int i = 0; i < anchors.count; i++) {
+        ARPlaneAnchor *anchor = (ARPlaneAnchor *)anchors[i];
+        matrix_float4x4 anchorTransform = anchor.transform;
+        const float *anchorMatrix = (const float *)(&anchorTransform);
+        //NSLog(@"Plane extent (native) %@", [NSString stringWithFormat: @"%f,%f,%f", anchor.extent.x, anchor.extent.y, anchor.extent.z]);
+        NSString *anchorStr = [NSString stringWithFormat:
+                               @"{\"transform\":[%f,%f,%f,%f,%f,%f,%f,%"
+                               @"f,%f,%f,%f,%f,%f,%f,%f,%f],"
+                               @"\"identifier\":%i,"
+                               @"\"alignment\":%i,"
+                               @"\"center\":[%f,%f,%f],"
+                               @"\"extent\":[%f,%f]}",
+                               anchorMatrix[0], anchorMatrix[1], anchorMatrix[2],
+                               anchorMatrix[3], anchorMatrix[4], anchorMatrix[5],
+                               anchorMatrix[6], anchorMatrix[7], anchorMatrix[8],
+                               anchorMatrix[9], anchorMatrix[10], anchorMatrix[11],
+                               anchorMatrix[12], anchorMatrix[13], anchorMatrix[14],
+                               anchorMatrix[15],
+                               (int)anchor.identifier,
+                               (int)anchor.alignment,
+                               anchor.center.x, anchor.center.y, anchor.center.z,
+                               anchor.extent.x, anchor.extent.z];
+        if (i < anchors.count - 1) {
+            anchorStr = [anchorStr stringByAppendingString:@","];
+        }
+        anchorsStr = [anchorsStr stringByAppendingString:anchorStr];
+    }
+    anchorsStr = [anchorsStr stringByAppendingString:@"]"];
+    
+    NSString *jsCode = [NSString
+                        stringWithFormat:@"if (window.WebARonARKitAnchorEvent) "
+                        @"window.WebARonARKitAnchorEvent({"
+                        @"\"type\":\"%@\","
+                        @"\"anchors\":%@"
+                        @"});",
+                        type,
+                        anchorsStr];
+    
+    [self->wkWebView
+     evaluateJavaScript:jsCode
+     completionHandler:^(id data, NSError *error) {
+         if (error) {
+             [self showAlertDialog:
+              [NSString stringWithFormat:@"ERROR: Evaluating jscode: %@",
+               error]
+                 completionHandler:^{
+                 }];
+         }
+     }];
+}
+
+- (void)session:(ARSession *)session didAddAnchors:(nonnull NSArray<ARAnchor *> *)anchors
+{
+    // The session added anchors; notify the JS side about it.
+    [self session:session notifyAnchorEvent:@"Added" anchors:anchors];
+}
+
+- (void)session:(ARSession *)session didUpdateAnchors:(nonnull NSArray<ARAnchor *> *)anchors
+{
+    // The session updated anchors; notify the JS side about it.
+    [self session:session notifyAnchorEvent:@"Updated" anchors:anchors];
+}
+
+- (void)session:(ARSession *)session didRemoveAnchors:(nonnull NSArray<ARAnchor *> *)anchors
+{
+    // The session removed anchors; notify the JS side about it.
+    [self session:session notifyAnchorEvent:@"Removed" anchors:anchors];
+}
+
 #pragma mark - WKUIDelegate
 
 - (void)webView:(WKWebView *)webView

--- a/WebARonARKit/WebARonARKit/ViewController.m
+++ b/WebARonARKit/WebARonARKit/ViewController.m
@@ -19,8 +19,13 @@
 #import "ProgressView.h"
 
 // TODO: Should this be a percentage?
-#define URL_TEXTFIELD_HEIGHT 44
+#define URL_TEXTFIELD_HEIGHT 36 // (I like it a little smaller, with some top margin.)
 #define PROGRESSVIEW_HEIGHT 4
+// Make navigation bar and controls translucent.
+#define ALPHA 0.3
+// Define some margin from top, left and right of screen.
+#define TOP_MARGIN 8
+#define LEFT_RIGHT_MARGIN 8
 
 @interface ViewController () <MTKViewDelegate, ARSessionDelegate>
 
@@ -228,7 +233,7 @@
                             renderDestinationProvider:view];
 
     [self.renderer drawRectResized:view.bounds.size];
-
+/*
     UITapGestureRecognizer *tapGesture =
         [[UITapGestureRecognizer alloc] initWithTarget:self
                                                 action:@selector(handleTap:)];
@@ -236,7 +241,7 @@
     [gestureRecognizers addObject:tapGesture];
     [gestureRecognizers addObjectsFromArray:view.gestureRecognizers];
     view.gestureRecognizers = gestureRecognizers;
-
+*/
     // Clear the webview completely
     //    NSSet *websiteDataTypes = [NSSet setWithArray:@[
     //        WKWebsiteDataTypeDiskCache,
@@ -278,11 +283,11 @@
         [[WKWebViewConfiguration alloc] init];
     wkWebViewConfig.userContentController = userContentController;
     // Create the WKWebView using the configuration/script injection and add it to
-    // the top of the view graph
+    // the top of the view graph; make sure it is fullscreen to match camera view.
     self->wkWebView = [[WKWebView alloc]
         initWithFrame:CGRectMake(
-                          0, URL_TEXTFIELD_HEIGHT, self.view.frame.size.width,
-                          self.view.frame.size.height - URL_TEXTFIELD_HEIGHT)
+                          0, 0, self.view.frame.size.width,
+                          self.view.frame.size.height)
         configuration:wkWebViewConfig];
     self->wkWebViewOriginalBackgroundColor = self->wkWebView.backgroundColor;
     // By default, the camera feed won't be shown until instructed otherwise
@@ -290,18 +295,19 @@
     [self->wkWebView.configuration.preferences
         setValue:@TRUE
           forKey:@"allowFileAccessFromFileURLs"];
-    [self setWKWebViewScrollEnabled:true];
+    // Set scrollEnabled to false, to avoid flicker on touch.
+    [self setWKWebViewScrollEnabled:false];
     // Needed to show alerts. Check the WKUIDelegate protocol and the
     // runJavaScriptAlertPanelWithMessage method in this file :(
     self->wkWebView.UIDelegate = self;
     self->wkWebView.navigationDelegate = self;
     [self.view addSubview:self->wkWebView];
-    
+
     // Add a textfield for the URL on top of the webview
-    self->urlTextField = [[UITextField alloc]
-        initWithFrame:CGRectMake(URL_TEXTFIELD_HEIGHT, 0, self.view.frame.size.width - URL_TEXTFIELD_HEIGHT * 2,
-                                 URL_TEXTFIELD_HEIGHT)];
-    [self->urlTextField setBackgroundColor:[UIColor whiteColor]];
+    self->urlTextField = [[UITextField alloc] initWithFrame:CGRectMake(
+      URL_TEXTFIELD_HEIGHT + LEFT_RIGHT_MARGIN, TOP_MARGIN,
+      self.view.frame.size.width - (URL_TEXTFIELD_HEIGHT + LEFT_RIGHT_MARGIN) * 2, URL_TEXTFIELD_HEIGHT)];
+    [self->urlTextField setBackgroundColor:[UIColor colorWithRed:1.0f green:1.0f blue:1.0f alpha:ALPHA]];
     [self->urlTextField setTextColor:[UIColor colorWithRed:0.2f green:0.2f blue:0.2f alpha:1.0]];
     [self->urlTextField setKeyboardType:UIKeyboardTypeURL];
     [self->urlTextField setAutocorrectionType:UITextAutocorrectionTypeNo];
@@ -310,15 +316,19 @@
     [self.view addSubview:self->urlTextField];
 
     // Add the back/refresh buttons
-    self->backButton = [[UIButton alloc] initWithFrame:CGRectMake(0, 0, URL_TEXTFIELD_HEIGHT, URL_TEXTFIELD_HEIGHT)];
-    self->backButton.backgroundColor = [UIColor whiteColor];
+    self->backButton = [[UIButton alloc] initWithFrame:CGRectMake(
+      LEFT_RIGHT_MARGIN, TOP_MARGIN,
+      URL_TEXTFIELD_HEIGHT, URL_TEXTFIELD_HEIGHT)];
+    self->backButton.backgroundColor = [UIColor colorWithRed:1.0f green:1.0f blue:1.0f alpha:ALPHA];
     UIImage *backIcon = [UIImage imageNamed:@"BackIcon"];
     [self->backButton setImage:backIcon forState:UIControlStateNormal];
     [self->backButton addTarget:self action:@selector(backButtonClicked:) forControlEvents:UIControlEventTouchDown];
     [self.view addSubview:self->backButton];
 
-    self->refreshButton = [[UIButton alloc] initWithFrame:CGRectMake(self.view.frame.size.width - URL_TEXTFIELD_HEIGHT, 0, URL_TEXTFIELD_HEIGHT, URL_TEXTFIELD_HEIGHT)];
-    [self->refreshButton setBackgroundColor:[UIColor whiteColor]];
+    self->refreshButton = [[UIButton alloc] initWithFrame:CGRectMake(
+      self.view.frame.size.width - URL_TEXTFIELD_HEIGHT - LEFT_RIGHT_MARGIN, TOP_MARGIN,
+      URL_TEXTFIELD_HEIGHT, URL_TEXTFIELD_HEIGHT)];
+    [self->refreshButton setBackgroundColor:[UIColor colorWithRed:1.0f green:1.0f blue:1.0f alpha:ALPHA]];
     UIImage *refreshIcon = [UIImage imageNamed:@"RefreshIcon"];
     [self->refreshButton setImage:refreshIcon forState:UIControlStateNormal];
     [self->refreshButton addTarget:self action:@selector(refreshButtonClicked:) forControlEvents:UIControlEventTouchDown];
@@ -328,7 +338,7 @@
     [self initProgressView];
     //Observe the estimatedProgress to uodate progress view
     [self->wkWebView addObserver:self forKeyPath:NSStringFromSelector(@selector(estimatedProgress)) options:NSKeyValueObservingOptionNew context:NULL];
-    
+
     // Load the default website
     NSString *defaultSite = @"https://developers.google.com/ar/develop/web/getting-started#examples";
     NSURL *url = [NSURL URLWithString:defaultSite];
@@ -403,14 +413,20 @@
 
 - (void)deviceOrientationDidChange:(NSNotification *)notification
 {
-    [self->urlTextField setFrame:CGRectMake(URL_TEXTFIELD_HEIGHT, 0, self.view.frame.size.width - URL_TEXTFIELD_HEIGHT * 2, URL_TEXTFIELD_HEIGHT)];
+    [self->urlTextField setFrame:CGRectMake(
+      URL_TEXTFIELD_HEIGHT + LEFT_RIGHT_MARGIN, TOP_MARGIN,
+      self.view.frame.size.width - (URL_TEXTFIELD_HEIGHT + LEFT_RIGHT_MARGIN) * 2, URL_TEXTFIELD_HEIGHT)];
 
-    [self->refreshButton setFrame:CGRectMake(self.view.frame.size.width - URL_TEXTFIELD_HEIGHT, 0, URL_TEXTFIELD_HEIGHT, URL_TEXTFIELD_HEIGHT)];
+    [self->refreshButton setFrame:CGRectMake(
+      self.view.frame.size.width - URL_TEXTFIELD_HEIGHT - LEFT_RIGHT_MARGIN, TOP_MARGIN,
+      URL_TEXTFIELD_HEIGHT, URL_TEXTFIELD_HEIGHT)];
 
-    [self->wkWebView setFrame:CGRectMake(0, URL_TEXTFIELD_HEIGHT, self.view.frame.size.width,
-                                         self.view.frame.size.height - URL_TEXTFIELD_HEIGHT)];
+    [self->wkWebView setFrame:CGRectMake(0, 0, self.view.frame.size.width,
+                                         self.view.frame.size.height)];
 
-    [self.progressView setFrame:CGRectMake(0, URL_TEXTFIELD_HEIGHT - PROGRESSVIEW_HEIGHT, self.view.frame.size.width, PROGRESSVIEW_HEIGHT)];
+    [self.progressView setFrame:CGRectMake(
+      LEFT_RIGHT_MARGIN, TOP_MARGIN + URL_TEXTFIELD_HEIGHT - PROGRESSVIEW_HEIGHT,
+      self.view.frame.size.width - LEFT_RIGHT_MARGIN * 2, PROGRESSVIEW_HEIGHT)];
     
     [self updateOrientation];
     updateWindowSize = true;
@@ -479,6 +495,7 @@
     // Release any cached data, images, etc that aren't in use.
 }
 
+/*
 - (void)handleTap:(UIGestureRecognizer *)gestureRecognize
 {
     ARFrame *currentFrame = [self.session currentFrame];
@@ -497,6 +514,7 @@
         [self.session addAnchor:anchor];
     }
 }
+*/
 
 #pragma mark - MTKViewDelegate
 


### PR DESCRIPTION
Additional recommended changes atop #3.
 
Sync: in an experiment to achieve better camera / render sync, wait for up to 2ms after the bridge call to set data.

Fullscreen: it turns out that although the ARKit camera view was fullscreen, the WKWebView was not, which presumably caused small misalignment issues.  To rectify, make the WKWebView fill the whole screen to match camera view.  Also, make corresponding stylistic changes to the controls. 

Also: disable scrolling on the WKWebView, to avoid flickering on tap.

TODO: provide some method to hide the controls...