### PR TITLE
The raf call shims should pass the current time.

### DIFF
--- a/WebARonARKit/WebARonARKit.js
+++ b/WebARonARKit/WebARonARKit.js
@@ -990,7 +990,7 @@
     }
     rafCallbacks = [];
     for (var i = 0; i < rafCallbacksCopy.length; i++) {
-      rafCallbacksCopy[i]();
+      rafCallbacksCopy[i](performance.now());
     }
   }
 


### PR DESCRIPTION
RAF assumes that the current time will be passes to the RAF callback. The RAF polyfill was not passing the current time. This patch fixes this.