### PR TITLE
fix exception when planesupdated but plane is missing for some reason

### DIFF
--- a/WebARonARKit/WebARonARKit.js
+++ b/WebARonARKit/WebARonARKit.js
@@ -1063,7 +1063,12 @@
           } else if (event.type === "planesupdated") {
             // Update the plane
             plane = WebARonARKitVRDisplay.planes_.get(eventPlane.identifier);
-            plane.set_(eventPlane);
+            if (plane) {
+              plane.set_(eventPlane);
+            } else {
+              plane = new VRPlane(eventPlane);
+              WebARonARKitVRDisplay.planes_.set(plane.identifier, plane);
+            }
           } else if (event.type === "planesremoved") {
             // If the plane has been removed, remove the actual VRPlane instance.
             plane = WebARonARKitVRDisplay.planes_.get(eventPlane.identifier);


### PR DESCRIPTION
I noticed that https://ar-painter.glitch.me/ar.html was now throwing exceptions, apparently when planesupdated event fires but for some reason the plane is not yet available.  This PR modifies behavior to add the plane if not present. 