### PR TITLE
Added support for passing the camera frame from ObjectiveC to JS.

### DIFF
--- a/WebARonARKit/WebARonARKit.js
+++ b/WebARonARKit/WebARonARKit.js
@@ -330,10 +330,12 @@
       // TODO: Learn fom the WebVR Polyfill how to make the barrel distortion.
     };
 
-    if (window.WebARonARKitUsesCameraFrames) {
+    if (window.WebARonARKitSendsCameraFrames) {
       // On WebARonARKit, the pass through camera can be simulated using an
       // image.
       this.passThroughCameraImage_ = document.createElement("img");
+      this.passThroughCameraImage_.textureWidth = 0;
+      this.passThroughCameraImage_.textureHeight = 0;
       this.passThroughCameraImage_.focalLengthX = 0;
       this.passThroughCameraImage_.focalLengthY = 0;
       this.passThroughCameraImage_.pointX = 0;
@@ -341,8 +343,8 @@
       this.passThroughCameraImage_.orientation = 90;
 
       this.passThroughCameraImage_.addEventListener("load", function(event) {
-        event.target.videoTextureWidth = event.target.width; 
-        event.target.videoTextureHeight = event.target.height;
+        event.target.textureWidth = event.target.width; 
+        event.target.textureHeight = event.target.height;
 
         // Now we can call the callbacks as we know that the camera frame is
         // loaded in the image. This makes the synchronization to be "perfect".
@@ -353,6 +355,10 @@
       });
 
       /**
+      * Returns an instance that represents the camera pass through.
+      *
+      * @return {HTMLImageElement} An instance that represents the camera
+      * pass through.
       */
       this.getPassThroughCamera = function() {
         return this.passThroughCameraImage_;
@@ -1050,7 +1056,7 @@
     }
 
     // Did the native side pass the camera frame? Then update the image!
-    if (window.WebARonARKitUsesCameraFrames && data.cameraFrame !== "") {
+    if (window.WebARonARKitSendsCameraFrames && data.cameraFrame !== "") {
       WebARonARKitVRDisplay.passThroughCameraImage_.src = data.cameraFrame;
       // The raf callbacks and the advance of the frame will be done once the
       // image is loaded (see the image load event above)

--- a/WebARonARKit/WebARonARKit.xcodeproj/project.pbxproj
+++ b/WebARonARKit/WebARonARKit.xcodeproj/project.pbxproj
@@ -314,10 +314,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				DEVELOPMENT_TEAM = EQHXZ8M8AV;
+				DEVELOPMENT_TEAM = ETH8NG5FR9;
 				INFOPLIST_FILE = "$(SRCROOT)/WebARonARKit/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = Google.WebARonARKit;
+				PRODUCT_BUNDLE_IDENTIFIER = Google.AR.WebARonARKit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -327,10 +327,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				DEVELOPMENT_TEAM = EQHXZ8M8AV;
+				DEVELOPMENT_TEAM = ETH8NG5FR9;
 				INFOPLIST_FILE = "$(SRCROOT)/WebARonARKit/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = Google.WebARonARKit;
+				PRODUCT_BUNDLE_IDENTIFIER = Google.AR.WebARonARKit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};

--- a/WebARonARKit/WebARonARKit/Info.plist
+++ b/WebARonARKit/WebARonARKit/Info.plist
@@ -2,17 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>CFBundleURLTypes</key>
-	<array>
-		<dict>
-			<key>CFBundleURLName</key>
-			<string>com.google.webar</string>
-      <key>CFBundleURLSchemes</key>
-      <array>
-        <string>webar</string>
-      </array>
-		</dict>
-	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>
@@ -27,6 +16,17 @@
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>com.google.webar</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>webar</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
@@ -38,6 +38,8 @@
 	</dict>
 	<key>NSCameraUsageDescription</key>
 	<string>This application will use the camera for Augmented Reality.</string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>Allow location access from the WKWebView whenever is requested.</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
@@ -67,7 +69,5 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
-	<key>NSLocationWhenInUseUsageDescription</key>
-	<string>Allow location access from the WKWebView whenever is requested.</string>
 </dict>
 </plist>

--- a/WebARonARKit/WebARonARKit/ViewController.m
+++ b/WebARonARKit/WebARonARKit/ViewController.m
@@ -64,14 +64,14 @@ NSString *deviceName() {
 
 // Set this value to true or false to enable the passing of the camera
 // frame from the native side to the JS side in each frame.
-bool USE_CAMERA_FRAME = true;
+bool USE_CAMERA_FRAME = false;
 // On iOS 11.3 the webgl context transparency does not work any longer.
 // This flag checks the iOS version and forces to use the camera frames
 // in iOS 11.3 and beyond (this flag and check might disappear once the
 // webview problem is resolved by Apple).
 const bool FORCE_USE_CAMERA_FRAME_ON_IOS_11_3_AND_ABOVE = true;
 // Use these values to control the camera frame quality
-const float CAMERA_FRAME_SCALE_FACTOR = 0.3;
+const float CAMERA_FRAME_SCALE_FACTOR = 0.4;
 const float CAMERA_FRAME_JPEG_COMPRESSION_FACTOR = 0.5;
 
 @interface ViewController ()<MTKViewDelegate, ARSessionDelegate>

--- a/WebARonARKit/WebARonARKit/ViewController.m
+++ b/WebARonARKit/WebARonARKit/ViewController.m
@@ -242,21 +242,10 @@ const float CAMERA_FRAME_JPEG_COMPRESSION_FACTOR = 0.5;
         wkWebView.opaque = false;
         wkWebView.backgroundColor = [UIColor clearColor];
         wkWebView.scrollView.backgroundColor = [UIColor clearColor];
-        // Trying to resolve an issue with iPhoneX where the webview does not
-        // accopy the whole screen.
-        [wkWebView.scrollView
-            setContentInsetAdjustmentBehavior:
-            UIScrollViewContentInsetAdjustmentNever];
     } else {
         wkWebView.opaque = true;
         wkWebView.backgroundColor = wkWebViewOriginalBackgroundColor;
         wkWebView.scrollView.backgroundColor = wkWebViewOriginalBackgroundColor;
-        // Trying to resolve an issue with iPhoneX where the webview does not
-        // accopy the whole screen.
-        [wkWebView.scrollView
-            setContentInsetAdjustmentBehavior:
-            UIScrollViewContentInsetAdjustmentAutomatic];
-      
     }
     showingCameraFeed = show;
     NSLog(@"show camera feed: %@", show ? @"YES" : @"NO");
@@ -385,8 +374,10 @@ const float CAMERA_FRAME_JPEG_COMPRESSION_FACTOR = 0.5;
     // By default, the camera feed won't be shown until instructed otherwise
     [self setShowCameraFeed:NO];
 
+    // Fixes the webview scalling problem on iPhoneX.
     [wkWebView.scrollView
-     setContentInsetAdjustmentBehavior:UIScrollViewContentInsetAdjustmentNever];
+       setContentInsetAdjustmentBehavior:
+       UIScrollViewContentInsetAdjustmentNever];
 
     [wkWebView.configuration.preferences setValue:@TRUE
                                            forKey:@"allowFileAccessFromFileURLs"];


### PR DESCRIPTION
The feature can be configured from the native side (enable/disable) although for now, it will be anabled if the iOS version is 11.3 or above. Some changes in three.ar.js are needed so the texture can be rendered on iOS too if this feature is enabled.