### PR TITLE
allow inline media playback, without user gesture

### DIFF
--- a/WebARonARKit/WebARonARKit/ViewController.m
+++ b/WebARonARKit/WebARonARKit/ViewController.m
@@ -354,6 +354,10 @@ const float CAMERA_FRAME_JPEG_COMPRESSION_FACTOR = 0.5;
     WKWebViewConfiguration *wkWebViewConfig =
     [[WKWebViewConfiguration alloc] init];
     wkWebViewConfig.userContentController = userContentController;
+    
+    wkWebViewConfig.allowsInlineMediaPlayback = true;
+    wkWebViewConfig.mediaTypesRequiringUserActionForPlayback = WKAudiovisualMediaTypeNone;
+    
     // Create the WKWebView using the configuration/script injection and add it to
     // the top of the view graph
     wkWebView = [[WKWebView alloc] initWithFrame:self.view.frame


### PR DESCRIPTION
Currently WebARonARKit does not seem to handle media playback inline, and requires user gesture to initiate.  This PR should address both concerns.