### PR TITLE
'UIWebView' is deprecated from iOS 12.0

### DIFF
--- a/WebARonARKit/WebARonARKit/ViewController.m
+++ b/WebARonARKit/WebARonARKit/ViewController.m
@@ -1157,7 +1157,7 @@ didFailNavigation:(WKNavigation *)navigation
     [self completeAndHideProgressViewErrored:wkWebView.estimatedProgress];
 }
 
-- (void)webViewDidFinishLoad:(UIWebView *)webView {
+- (void)webViewDidFinishLoad:(WKWebView *)webView {
     [self restartSession];
     [self completeAndHideProgressViewSuccessful];
 }


### PR DESCRIPTION
This PR updates the deprecated UIWebView reference in 'ViewController.m' to WKWebView.